### PR TITLE
Make the path separator cross-platform

### DIFF
--- a/CommandLine/Program.cs
+++ b/CommandLine/Program.cs
@@ -51,7 +51,7 @@ namespace CommandLine
         exportTypeString = "Text List and JSON";
       }
 
-      string serverTypeString = "game";
+      string serverTypeString = "game"; // called game_x64 on my machine (linux)
       if (ServerType == ServerType.Staging)
       {
         serverTypeString = "staging";

--- a/Extractor/Extractors/BaseExtractor.cs
+++ b/Extractor/Extractors/BaseExtractor.cs
@@ -120,7 +120,7 @@ namespace Extractor.Extractors
     {
       var binFileWOE = Path.GetFileNameWithoutExtension(binFile);
 
-      var finalOutPath = Path.ChangeExtension(Path.Combine(outputFolderPath, binFile.Substring(binFile.LastIndexOf("GameData\\") + 9)), ".xml");
+      var finalOutPath = Path.ChangeExtension(Path.Combine(outputFolderPath, binFile.Substring(binFile.LastIndexOf("GameData" + Path.PathSeparator) + 9)), ".xml");
       Console.Out.WriteLine("Extracting " + binFileWOE + ".bin... to: "+ finalOutPath);
       Directory.CreateDirectory(Path.GetDirectoryName(finalOutPath));
 

--- a/Extractor/Extractors/BinaryDumper.cs
+++ b/Extractor/Extractors/BinaryDumper.cs
@@ -15,7 +15,7 @@ namespace Extractor.Extractors
       var outFiles = (string[])allFiles.Clone();
       for (var i = 0; i < outFiles.Length; i++)
       {
-        outFiles[i] = outFiles[i].Remove(0, outFiles[i].LastIndexOf("GameData\\") + "GameData\\".Length);
+        outFiles[i] = outFiles[i].Remove(0, outFiles[i].LastIndexOf("GameData"+Path.PathSeparator) + ("GameData"+Path.PathSeparator).Length);
       }
 
       for (var i = 0; i < allFiles.Length; i++)
@@ -26,7 +26,7 @@ namespace Extractor.Extractors
 
     private string GetBinFilePath(string mainGameFolder )
     {
-      return Path.Combine(mainGameFolder, @".\Albion-Online_Data\StreamingAssets\GameData");
+      return Path.Combine(mainGameFolder, ".", "Albion-Online_Data", "StreamingAssets" , "GameData");
     }
 
     private string DecryptBinFile(string outputFolderPath, string binFile, string subdir)

--- a/Extractor/Extractors/ItemExtractor.cs
+++ b/Extractor/Extractors/ItemExtractor.cs
@@ -125,7 +125,7 @@ namespace Extractor.Extractors
 
     protected override string GetBinFilePath()
     {
-      return Path.Combine(mainGameFolder, @".\Albion-Online_Data\StreamingAssets\GameData\items.bin");
+      return Path.Combine(mainGameFolder, ".", "Albion-Online_Data", "StreamingAssets", "GameData" , "items.bin");
     }
   }
 }

--- a/Extractor/Extractors/LocationExtractor.cs
+++ b/Extractor/Extractors/LocationExtractor.cs
@@ -41,7 +41,7 @@ namespace Extractor.Extractors
 
     protected override string GetBinFilePath()
     {
-      return Path.Combine(mainGameFolder, @".\Albion-Online_Data\StreamingAssets\GameData\cluster\world.bin");
+      return Path.Combine(mainGameFolder, ".", "Albion-Online_Data", "StreamingAssets", "GameData", "cluster" ,"world.bin");
     }
   }
 }

--- a/Extractor/Utils/LocalizationData.cs
+++ b/Extractor/Utils/LocalizationData.cs
@@ -18,7 +18,7 @@ namespace Extractor
 
     public LocalizationData(string mainGameFolder, string outputFolderPath)
     {
-      var xmlFileLocation = BaseExtractor.DecryptBinFile(Path.Combine(mainGameFolder, @".\Albion-Online_Data\StreamingAssets\GameData\localization.bin"), outputFolderPath);
+      var xmlFileLocation = BaseExtractor.DecryptBinFile(Path.Combine(mainGameFolder, ".", "Albion-Online_Data", "StreamingAssets", "GameData" , "localization.bin"), outputFolderPath);
 
       var xmlDoc = new XmlDocument();
       using (var inputStream = File.OpenRead(xmlFileLocation))


### PR DESCRIPTION
Hey, thanks for the tool!
I tried using it on linux but unfortunately it didn't work because of the path separators.
After changing every path I could find, it successfully dumped everything on my machine after also changing the `serverTypeString` in `CommandLine/Program.cs` to `game_x64`. 
I don't know if this a new name, or if it is linux only. So I left that unchanged and added a comment.